### PR TITLE
Mark API routes dynamic to avoid build timeouts

### DIFF
--- a/app/api/chat/send/route.ts
+++ b/app/api/chat/send/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { withRcon } from '@/lib/rcon';
 
 export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
 
 export async function POST(req: NextRequest) {
   const data = await req.formData();

--- a/app/api/status/route.ts
+++ b/app/api/status/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { withRcon } from '@/lib/rcon';
 
 export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
 
 function formatTime(ticks: number): string {
   const seconds = ticks / 60;

--- a/app/api/technologies/route.ts
+++ b/app/api/technologies/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { withRcon } from '@/lib/rcon';
 
 export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
 
 export async function GET() {
   try {


### PR DESCRIPTION
## Summary
- mark the RCON-backed API route handlers as dynamic so Next.js no longer tries to statically render them during the build, which prevents timeouts when Factorio is unreachable

## Testing
- npm run build


------
https://chatgpt.com/codex/tasks/task_e_68c9a3b61f8883259a981e58aaf7edc1